### PR TITLE
feat(docusaurus-plugin-stored-data): set up initial plugin code

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -38,6 +38,9 @@ export default async (): Promise<Config.InitialOptions> => {
   const createProjectConfig = await prepareProjectConfig();
 
   return {
-    projects: [createProjectConfig("jest-docusaurus")],
+    projects: [
+      createProjectConfig("jest-docusaurus"),
+      createProjectConfig("docusaurus-plugin-stored-data"),
+    ],
   };
 };

--- a/packages/docusaurus-plugin-stored-data/.npmignore
+++ b/packages/docusaurus-plugin-stored-data/.npmignore
@@ -1,0 +1,2 @@
+.tsbuildinfo*
+tsconfig*

--- a/packages/docusaurus-plugin-stored-data/README.md
+++ b/packages/docusaurus-plugin-stored-data/README.md
@@ -1,0 +1,93 @@
+# docusaurus-plugin-stored-data
+
+Load local or external data to be used in Docusaurus
+
+## Usage
+
+Start by installing the dependency:
+
+- Yarn: `yarn add @1password/docusaurus-plugin-stored-data`
+- NPM: `npm i @1password/docusaurus-plugin-stored-data`
+
+Add the plugin to your `docusaurus.config.js` file's "plugins" option. If you're new to Docusaurus plugins, [click here to learn more](https://docusaurus.io/docs/using-plugins) about installing and configuring them.
+
+These are the available plugin options:
+
+```ts
+type Options = {
+  /**
+   * Define key-value pairs, where the key is the ID you want to assign to the data,
+   * and the value is a local path or external URL to retrieve the data from.
+   */
+  data: Record<string, string>;
+};
+```
+
+Here's an example of how to set the plugin's options, loading both local and external data:
+
+```js
+// docusaurus.config.js
+const { resolve } = require("path");
+
+plugins: [
+  [
+    '@1password/docusaurus-plugin-stored-data',
+    {
+      data: {
+        "blog-feed": "https://example.com/blog.xml",
+        "rust-example": resolve(__dirname, "static", "example.rs"),
+      }
+    }
+  ]
+],
+```
+
+Now, when you start your dev server or build the site, the plugin will retrieve the contents of each location specified in the config and store it as plugin data. Access this data in your site using one of the plugin's hooks, which takes the ID and returns the data in various formats.
+
+The following hooks are available:
+
+- `@theme/useStoredData` - Returns the data unformatted
+- `@theme/useStoredJson` - Returns the data parsed as JSON
+- `@theme/useStoredFeed` - Returns the data parsed as RSS XML into JSON structure using [fast-xml-parser](https://www.npmjs.com/package/fast-xml-parser).
+
+Here's an example of how you might use the plugin to retrieve and render blog posts from an RSS feed:
+
+```jsx
+// FeedItems.tsx
+
+import useStoredFeed from "@theme/useStoredFeed";
+
+const FeedItems = () => {
+  const feedData = useStoredFeed("blog-feed");
+  return (
+    <ul>
+      {feedData.item.map((item) => (
+        <li key={item.guid}>{item.title}</li>
+      ))}
+    </ul>
+  );
+};
+```
+
+Or, if your data can be rendered without modification you can simply call a hook directly inside an MDX file:
+
+```jsx
+// example.mdx
+
+import CodeBlock from "@theme/CodeBlock";
+import useStoredData from "@theme/useStoredData";
+
+<CodeBlock language="rust">{useStoredData("rust-example")}</CodeBlock>;
+```
+
+If you're using TypeScript you will need to reference the plugin's types:
+
+```ts
+// types.d.ts
+
+/// <reference types="@1password/docusaurus-plugin-stored-data" />
+```
+
+## License
+
+MIT

--- a/packages/docusaurus-plugin-stored-data/package.json
+++ b/packages/docusaurus-plugin-stored-data/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@1password/docusaurus-plugin-stored-data",
+  "description": "Load local or external data to be used in Docusaurus",
+  "version": "0.1.0",
+  "author": "1Password <support@1password.com>",
+  "repository": {
+    "url": "https://github.com/1Password/docusaurus-extensions.git",
+    "type": "git",
+    "directory": "packages/docusaurus-plugin-stored-data"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.14"
+  },
+  "main": "dist/index.js",
+  "types": "src/plugin.d.ts",
+  "scripts": {
+    "build": "yarn clean && tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "test": "cd ../../ && yarn test --selectProjects=@1password/docusaurus-plugin-stored-data",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
+    "watch": "tsc --build --watch --preserveWatchOutput"
+  },
+  "dependencies": {
+    "@docusaurus/utils-validation": "^2.2.0",
+    "fast-xml-parser": "^4.0.11"
+  },
+  "devDependencies": {
+    "@1password/jest-docusaurus": "workspace:^",
+    "@docusaurus/module-type-aliases": "^2.2.0",
+    "@docusaurus/types": "^2.2.0",
+    "@types/jest": "^28.1.8",
+    "@types/node": "^16.14.0",
+    "@types/react": "^18.0.25",
+    "rimraf": "^3.0.2",
+    "tslib": "^2.4.0",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": "^2.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^16.8.4 || ^17.0.0"
+  }
+}

--- a/packages/docusaurus-plugin-stored-data/src/index.test.ts
+++ b/packages/docusaurus-plugin-stored-data/src/index.test.ts
@@ -1,0 +1,63 @@
+import { LoadedPlugin, loadPlugin } from "@1password/jest-docusaurus/plugin";
+import { IncomingMessage } from "http";
+import https from "https";
+import pluginStoredData from ".";
+
+jest.mock("https", () => ({
+  ...jest.requireActual("https"),
+  request: (
+    _: Parameters<typeof https.request>[0],
+    callback: (res: IncomingMessage) => void,
+  ) =>
+    callback({
+      // @ts-expect-error FIXME
+      on: (event, listener) => {
+        // eslint-disable-next-line default-case
+        switch (event) {
+          case "data":
+            (listener as (chunk: any) => void)(Buffer.from("test", "utf8"));
+            break;
+          case "end":
+            (listener as () => void)();
+            break;
+        }
+      },
+      statusCode: 200,
+      statusMessage: "API Success",
+    }),
+  on: jest.fn(),
+  end: jest.fn(),
+}));
+
+describe("docusaurus-plugin-statuspage", () => {
+  let plugin: LoadedPlugin<Record<string, any>>;
+
+  beforeEach(async () => {
+    plugin = await loadPlugin(pluginStoredData, {
+      data: {
+        foo: "https://example.com/feed.xml",
+        lorem: "https://example.com/feed.xml",
+      },
+    });
+  });
+
+  it("loads data for each object key-pair", async () => {
+    jest.spyOn(https, "request");
+    const data = await plugin.loadContent!();
+    expect(https.request).toHaveBeenCalledTimes(2);
+    expect(data).toEqual({
+      foo: "test",
+      lorem: "test",
+    });
+  });
+
+  it("sets the fetched data as global data", () => {
+    const data = { foo: "bar", lorem: "ipsum" };
+    jest.spyOn(plugin, "loadContent").mockResolvedValue(data);
+    expect(plugin).toSetGlobalData({ data });
+  });
+
+  it("loads correct theme paths", () => {
+    expect(plugin).toHaveThemePaths("dist/theme", "src/theme");
+  });
+});

--- a/packages/docusaurus-plugin-stored-data/src/index.ts
+++ b/packages/docusaurus-plugin-stored-data/src/index.ts
@@ -1,0 +1,123 @@
+import type { Options } from "@1password/docusaurus-plugin-stored-data";
+import type {
+  LoadContext,
+  OptionValidationContext,
+  Plugin,
+} from "@docusaurus/types";
+import { Joi } from "@docusaurus/utils-validation";
+import { lstat, readFile } from "fs/promises";
+import https from "https";
+
+const httpsPromise = (
+  options: Parameters<typeof https.request>[0],
+): Promise<{
+  statusCode?: number;
+  headers: NodeJS.Dict<string | string[]>;
+  body: string;
+}> =>
+  new Promise((resolve, reject) => {
+    const request = https.request(options, (response) => {
+      let body = "";
+      const { statusCode, headers } = response;
+
+      response.on("data", (chunk) => {
+        body += chunk.toString();
+      });
+      response.on("error", reject);
+      response.on("end", () => {
+        if (statusCode! >= 200 && statusCode! <= 299) {
+          return resolve({
+            statusCode,
+            headers,
+            body,
+          });
+        }
+
+        return reject(
+          new Error(
+            `Request failed. Status: ${response.statusCode}, body: ${body}`,
+          ),
+        );
+      });
+    });
+
+    request.on("error", reject);
+    request.end();
+  });
+
+const getData = async (location: string): Promise<string> => {
+  try {
+    new URL(location); // will throw if invalid URL
+
+    const response = await httpsPromise(location);
+    return response.body;
+  } catch (error) {
+    // If it's just an invalid URL, let it fall through to check if it's a file
+    if (
+      !(error instanceof TypeError) ||
+      !error.message.includes("Invalid URL")
+    ) {
+      throw error;
+    }
+  }
+
+  try {
+    const stat = await lstat(location);
+
+    if (stat.isFile()) {
+      return await readFile(location, "utf8");
+    }
+
+    throw new Error(`Location ${location} is not a file`);
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.startsWith("ENOENT")) {
+      throw error;
+    }
+  }
+
+  throw new Error(`Could not determine if ${location} is a URL or file`);
+};
+
+const pluginStoredData = (
+  _: LoadContext,
+  { data = {} }: Options,
+): Plugin<Record<string, any>> => ({
+  name: "docusaurus-plugin-stored-data",
+
+  async loadContent() {
+    const parsed = await Promise.all(
+      Object.entries(data).map(async ([name, location]) => [
+        name,
+        await getData(location),
+      ]),
+    );
+
+    return Object.fromEntries(parsed);
+  },
+
+  async contentLoaded({ content, actions: { setGlobalData } }) {
+    setGlobalData({
+      data: content,
+    });
+  },
+
+  getThemePath() {
+    return "../dist/theme";
+  },
+
+  getTypeScriptThemePath() {
+    return "../src/theme";
+  },
+});
+
+export default pluginStoredData;
+
+const pluginOptionsSchema = Joi.object<Options>({
+  data: Joi.object().pattern(Joi.string(), Joi.string()).optional(),
+});
+
+export const validateOptions = ({
+  validate,
+  options,
+}: OptionValidationContext<Partial<Options>, Options>): Options =>
+  validate(pluginOptionsSchema, options);

--- a/packages/docusaurus-plugin-stored-data/src/plugin.d.ts
+++ b/packages/docusaurus-plugin-stored-data/src/plugin.d.ts
@@ -1,0 +1,43 @@
+/// <reference types="@docusaurus/module-type-aliases" />
+/// <reference types="@1password/jest-docusaurus" />
+
+declare module "@1password/docusaurus-plugin-stored-data" {
+  import type { LoadContext, Plugin } from "@docusaurus/types";
+
+  export type Options = {
+    /**
+     * Define key-value pairs, where the key is the ID you want to assign to the data,
+     * and the value is a local path or external URL to retrieve the data from.
+     */
+    data: Record<string, string>;
+  };
+
+  export default function pluginStoredData(
+    context: LoadContext,
+    options: Options,
+  ): Plugin<Record<string, any>>;
+}
+
+declare module "@theme/useStoredData" {
+  /**
+   * Retrieve stored data
+   */
+  const useStoredData: <T>(id: string) => T;
+  export default useStoredData;
+}
+
+declare module "@theme/useStoredJson" {
+  /**
+   * Retrieve stored data as JSON
+   */
+  const useStoredJson: <T = Record<string, any>>(id: string) => T;
+  export default useStoredJson;
+}
+
+declare module "@theme/useStoredFeed" {
+  /**
+   * Retrieve stored feed data, parsing the XML into JSON
+   */
+  const useStoredFeed: <T = Record<string, any>>(id: string) => T;
+  export default useStoredFeed;
+}

--- a/packages/docusaurus-plugin-stored-data/src/theme/useStoredData/index.ts
+++ b/packages/docusaurus-plugin-stored-data/src/theme/useStoredData/index.ts
@@ -1,0 +1,11 @@
+import { usePluginData } from "@docusaurus/useGlobalData";
+
+const useStoredData = <T>(id: string): T => {
+  const pluginData = usePluginData("docusaurus-plugin-stored-data") as Record<
+    string,
+    any
+  >;
+  return pluginData.data[id];
+};
+
+export default useStoredData;

--- a/packages/docusaurus-plugin-stored-data/src/theme/useStoredFeed/index.ts
+++ b/packages/docusaurus-plugin-stored-data/src/theme/useStoredFeed/index.ts
@@ -1,0 +1,23 @@
+import useStoredData from "@theme/useStoredData";
+import { XMLParser } from "fast-xml-parser";
+
+const useStoredFeed = <T = Record<string, any>>(id: string): Promise<T> => {
+  const parser = new XMLParser();
+  const data = useStoredData<string>(id);
+  let xml = parser.parse(data);
+
+  try {
+    const { channel } = xml.rss;
+    if (!channel) {
+      throw new Error("Channel data not found");
+    }
+    xml = channel;
+  } catch {
+    // most rss feeds will be structured like the above, but
+    // if it's a non-standard feed don't try to drill down
+  }
+
+  return xml;
+};
+
+export default useStoredFeed;

--- a/packages/docusaurus-plugin-stored-data/src/theme/useStoredJson/index.ts
+++ b/packages/docusaurus-plugin-stored-data/src/theme/useStoredJson/index.ts
@@ -1,0 +1,8 @@
+import useStoredData from "@theme/useStoredData";
+
+const useStoredJson = <T = Record<string, any>>(id: string): T => {
+  const data = useStoredData<string>(id);
+  return JSON.parse(data);
+};
+
+export default useStoredJson;

--- a/packages/docusaurus-plugin-stored-data/tsconfig.build.json
+++ b/packages/docusaurus-plugin-stored-data/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/docusaurus-plugin-stored-data/tsconfig.client.json
+++ b/packages/docusaurus-plugin-stored-data/tsconfig.client.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo-client",
+    "module": "esnext",
+    "target": "esnext",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/theme", "src/*.d.ts"]
+}

--- a/packages/docusaurus-plugin-stored-data/tsconfig.json
+++ b/packages/docusaurus-plugin-stored-data/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "./tsconfig.client.json" }],
+  "compilerOptions": {
+    "noEmit": false,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/theme"]
+}

--- a/website/docs/stored-data.mdx
+++ b/website/docs/stored-data.mdx
@@ -1,0 +1,35 @@
+import DevBlogPosts from "@theme/DevBlogPosts";
+import OpRepos from "@theme/OpRepos";
+import CodeBlock from "@theme/CodeBlock";
+import useStoredData from "@theme/useStoredData";
+
+# Stored Data
+
+:::info
+
+This page demonstrates usage of the `@1password/docusaurus-plugin-stored-data` plugin. It is used to consume data from both local and external sources and make it available via React hooks. Refer to the [package's README](https://github.com/1Password/docusaurus-extensions/blob/main/packages/docusaurus-plugin-stored-data) for detailed usage instructions.
+
+:::
+
+### RSS feed
+
+This example configures the plugin to consume an RSS feed and then uses the `useStoredFeed` hook in a custom component to parse and render individual feed items.
+
+<DevBlogPosts />
+
+### Stored code snippet
+
+This example configures the plugin to consume an external [code snippet from GitHub](https://github.com/1Password/arboard/blob/master/examples/get_image.rs) and then uses the `useStoredData` hook right in the MDX file to print the result into a `<CodeBlock>` component.
+
+<CodeBlock
+  language="rust"
+  title="/arboard/master/examples/get_image.rs"
+  showLineNumbers>
+  {useStoredData("arboard-get-image")}
+</CodeBlock>
+
+### Local files
+
+This example configures the plugin to consume the contents of a local JSON file containing a list of 1Password repositories and then uses the `useStoredJson` hook in a custom component to parse and render each repo.
+
+<OpRepos />

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,6 +3,7 @@
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const { resolve } = require("path");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -16,7 +17,21 @@ const config = {
   organizationName: "1password",
   projectName: "docusaurus-plugins",
 
-  plugins: [],
+  plugins: [
+    [
+      "@1password/docusaurus-plugin-stored-data",
+      /** @type {import('@1password/docusaurus-plugin-stored-data').Options} */
+      ({
+        data: {
+          "op-dev-blog":
+            "https://blog.1password.com/categories/developers/index.xml",
+          "arboard-get-image":
+            "https://raw.githubusercontent.com/1Password/arboard/master/examples/get_image.rs",
+          "op-repos": resolve(__dirname, "static", "repos.json"),
+        },
+      }),
+    ],
+  ],
 
   i18n: {
     defaultLocale: "en",
@@ -68,6 +83,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ["rust"],
       },
     }),
 };

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,7 @@
     ]
   },
   "dependencies": {
+    "@1password/docusaurus-plugin-stored-data": "workspace:^",
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",

--- a/website/src/theme/DevBlogPosts/index.tsx
+++ b/website/src/theme/DevBlogPosts/index.tsx
@@ -1,0 +1,24 @@
+import useStoredFeed from "@theme/useStoredFeed";
+import React from "react";
+
+const DevBlogPosts = () => {
+  const data = useStoredFeed<{
+    item: {
+      guid: string;
+      title: string;
+      link: string;
+    }[];
+  }>("op-dev-blog");
+
+  return (
+    <ul>
+      {data.item.slice(0, 5).map((post) => (
+        <li key={post.guid}>
+          <a href={post.link}>{post.title}</a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default DevBlogPosts;

--- a/website/src/theme/OpRepos/index.tsx
+++ b/website/src/theme/OpRepos/index.tsx
@@ -1,0 +1,24 @@
+import useStoredJson from "@theme/useStoredJson";
+import React from "react";
+
+const OpRepos = () => {
+  const data = useStoredJson<
+    {
+      name: string;
+      language: string;
+      url: string;
+    }[]
+  >("op-repos");
+
+  return (
+    <ul>
+      {data.map((repo) => (
+        <li key={repo.name}>
+          <a href={repo.url}>{repo.name}</a>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default OpRepos;

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -1,2 +1,2 @@
-/// <reference types="@1password/docusaurus-plugin-external-data" />
+/// <reference types="@1password/docusaurus-plugin-stored-data" />
 /// <reference types="@1password/docusaurus-plugin-ga-feedback" />

--- a/website/static/repos.json
+++ b/website/static/repos.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "onepassword-operator",
+    "language": "Go",
+    "url": "https://github.com/1Password/onepassword-operator"
+  },
+  {
+    "name": "connect-sdk-js",
+    "language": "TypeScript",
+    "url": "https://github.com/1Password/connect-sdk-js"
+  },
+  {
+    "name": "connect-helm-charts",
+    "language": "Smarty",
+    "url": "https://github.com/1Password/connect-helm-charts"
+  },
+  {
+    "name": "sys-locale",
+    "language": "Rust",
+    "url": "https://github.com/1Password/sys-locale"
+  },
+  {
+    "name": "arboard",
+    "language": "Rust",
+    "url": "https://github.com/1Password/arboard"
+  },
+  {
+    "name": "scim-examples ",
+    "language": "HCL",
+    "url": "https://github.com/1Password/scim-examples"
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,28 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@1password/docusaurus-plugin-stored-data@workspace:^, @1password/docusaurus-plugin-stored-data@workspace:packages/docusaurus-plugin-stored-data":
+  version: 0.0.0-use.local
+  resolution: "@1password/docusaurus-plugin-stored-data@workspace:packages/docusaurus-plugin-stored-data"
+  dependencies:
+    "@1password/jest-docusaurus": "workspace:^"
+    "@docusaurus/module-type-aliases": ^2.2.0
+    "@docusaurus/types": ^2.2.0
+    "@docusaurus/utils-validation": ^2.2.0
+    "@types/jest": ^28.1.8
+    "@types/node": ^16.14.0
+    "@types/react": ^18.0.25
+    fast-xml-parser: ^4.0.11
+    rimraf: ^3.0.2
+    tslib: ^2.4.0
+    typescript: ^4.7.4
+  peerDependencies:
+    "@docusaurus/core": ^2.2.0
+    react: ^17.0.2
+    react-dom: ^16.8.4 || ^17.0.0
+  languageName: unknown
+  linkType: soft
+
 "@1password/jest-docusaurus@workspace:^, @1password/jest-docusaurus@workspace:packages/jest-docusaurus":
   version: 0.0.0-use.local
   resolution: "@1password/jest-docusaurus@workspace:packages/jest-docusaurus"
@@ -2232,7 +2254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.2.0":
+"@docusaurus/utils-validation@npm:2.2.0, @docusaurus/utils-validation@npm:^2.2.0":
   version: 2.2.0
   resolution: "@docusaurus/utils-validation@npm:2.2.0"
   dependencies:
@@ -8975,6 +8997,17 @@ __metadata:
   dependencies:
     punycode: ^1.3.2
   checksum: 5043d0c4a8d775ff58504d56c096563c11b113e4cb8a2668c6f824a1cd4fb3812e2fdf76537eb24a7ce4ae7def6bd9747da630c617cf2a4b6ce0c42514e4f21c
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^4.0.11":
+  version: 4.0.11
+  resolution: "fast-xml-parser@npm:4.0.11"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: d8a08e4d5597e0fc00a86735195872eeb03008913e298830941516f3766e16ee555e2d431acc92e1dda887938edc445252ec5b59494aab60a8389888bd13719c
   languageName: node
   linkType: hard
 
@@ -16606,6 +16639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
+  languageName: node
+  linkType: hard
+
 "strong-log-transformer@npm:^2.1.0":
   version: 2.1.0
   resolution: "strong-log-transformer@npm:2.1.0"
@@ -18153,6 +18193,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "website@workspace:website"
   dependencies:
+    "@1password/docusaurus-plugin-stored-data": "workspace:^"
     "@docusaurus/core": ^2.2.0
     "@docusaurus/module-type-aliases": ^2.2.0
     "@docusaurus/plugin-content-docs": ^2.2.0


### PR DESCRIPTION
ℹ️ Base set to `jh/website-setup` until https://github.com/1Password/docusaurus-extensions/pull/10 is merged.

This PR introduces the first Docusaurus plugin we're going to start distributing: `@1password/docusaurus-plugin-stored-data`. It serves a simple purpose: get data from somewhere and let you use it anywhere in Docusaurus.

It does a few things under the hood:

- It is configured by supplying a key-value object of IDs and locations, where the location can either be a fully-qualified URL, or it can be a local file path.
- The plugin will attempt to figure out the type of location and then retrieve data using the appropriate method.
- Data is loaded when you build the site (e.g. `yarn start` or `yarn build`) and stored as plugin data.
- You can retrieve the stored plugin data using one of three hooks:
  - `useStoredData` will retrieve the data unmodified
  - `useStoredJson` will retrieve the data and parse it as JSON
  - `useStoredFeed` will retrieve the data and parse it as XML out to JSON

A full demonstration is available if you run the Docusaurus example instance locally.

Refer to the [README](https://github.com/1Password/docusaurus-extensions/tree/jh/plugin-stored-data/packages/docusaurus-plugin-stored-data#readme) to better understand the usage and examples.