### PR TITLE
[DEV] react + react-dom to 18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/jest": "^28.1.8",
     "@types/node": "^18.11.17",
     "@types/prettier": "^2.7.1",
+    "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "concurrently": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
   },
   "packageManager": "yarn@3.2.2",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^16.8.4 || ^17.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "syncpack": {
     "workspace": false,

--- a/packages/docusaurus-plugin-stored-data/package.json
+++ b/packages/docusaurus-plugin-stored-data/package.json
@@ -31,7 +31,7 @@
     "@docusaurus/types": "^2.3.1",
     "@types/jest": "^28.1.8",
     "@types/node": "^18.11.17",
-    "@types/react": "^18.0.25",
+    "@types/react": "^18.2.0",
     "rimraf": "^3.0.2",
     "tslib": "^2.4.0",
     "typescript": "^4.7.4"

--- a/packages/docusaurus-plugin-stored-data/package.json
+++ b/packages/docusaurus-plugin-stored-data/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.3.1",
-    "react": "^17.0.2",
-    "react-dom": "^16.8.4 || ^17.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/jest-docusaurus/package.json
+++ b/packages/jest-docusaurus/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^16.8.4 || ^17.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/jest-docusaurus/package.json
+++ b/packages/jest-docusaurus/package.json
@@ -28,7 +28,7 @@
     "@docusaurus/types": "^2.3.1",
     "@jest/types": "^29.4.1",
     "@types/jest": "^28.1.8",
-    "@types/react": "^18.0.25",
+    "@types/react": "^18.2.0",
     "@types/react-router-dom": "^5.3.3",
     "rimraf": "^3.0.2",
     "tslib": "^2.4.0",

--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,7 @@
     "@docusaurus/types": "^2.3.1",
     "@tsconfig/docusaurus": "^1.0.6",
     "@types/node": "^18.11.17",
+    "@types/react": "^18.2.0",
     "typescript": "^4.7.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -29,8 +29,8 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
     "@docusaurus/utils-validation": ^2.3.1
     "@types/jest": ^28.1.8
     "@types/node": ^18.11.17
-    "@types/react": ^18.0.25
+    "@types/react": ^18.2.0
     fast-xml-parser: ^4.0.11
     rimraf: ^3.0.2
     tslib: ^2.4.0
@@ -36,7 +36,7 @@ __metadata:
     "@docusaurus/types": ^2.3.1
     "@jest/types": ^29.4.1
     "@types/jest": ^28.1.8
-    "@types/react": ^18.0.25
+    "@types/react": ^18.2.0
     "@types/react-router-dom": ^5.3.3
     rimraf: ^3.0.2
     tslib: ^2.4.0
@@ -4814,7 +4814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^18.0.25":
+"@types/react@npm:*":
   version: 18.0.25
   resolution: "@types/react@npm:18.0.25"
   dependencies:
@@ -4822,6 +4822,16 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: 231d658c45abdef044a716b4502774f1585d8336d73b2f5bd68f181acbfc874b7a457686ecd29b415b43ed0922c309bab7e2cf96832d188a3f4f1b02f2af760a
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.2.0":
+  version: 18.2.79
+  resolution: "@types/react@npm:18.2.79"
+  dependencies:
+    "@types/prop-types": "*"
+    csstype: ^3.0.2
+  checksum: 85aa96e0e88725c84d8fc5f04f10a4da6a1f507dde33557ac9cc211414756867721264bfefd9e02bae1288ce2905351d949b652b931e734ea24519ee5c625138
   languageName: node
   linkType: hard
 
@@ -8087,6 +8097,7 @@ __metadata:
     "@types/jest": ^28.1.8
     "@types/node": ^18.11.17
     "@types/prettier": ^2.7.1
+    "@types/react": ^18.2.0
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
     concurrently: ^7.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,8 +22,8 @@ __metadata:
     typescript: ^4.7.4
   peerDependencies:
     "@docusaurus/core": ^2.3.1
-    react: ^17.0.2
-    react-dom: ^16.8.4 || ^17.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
   languageName: unknown
   linkType: soft
 
@@ -42,8 +42,8 @@ __metadata:
     tslib: ^2.4.0
     typescript: ^4.7.4
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^16.8.4 || ^17.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
   languageName: unknown
   linkType: soft
 
@@ -15364,16 +15364,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -15516,13 +15515,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -16195,13 +16193,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 
@@ -18628,8 +18625,8 @@ __metadata:
     "@types/node": ^18.11.17
     clsx: ^1.2.1
     prism-react-renderer: ^1.3.5
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
     typescript: ^4.7.4
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -18634,6 +18634,7 @@ __metadata:
     "@mdx-js/react": ^1.6.22
     "@tsconfig/docusaurus": ^1.0.6
     "@types/node": ^18.11.17
+    "@types/react": ^18.2.0
     clsx: ^1.2.1
     prism-react-renderer: ^1.3.5
     react: ^18.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8115,8 +8115,8 @@ __metadata:
     tslib: ^2.4.0
     typescript: ^4.7.4
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^16.8.4 || ^17.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Upgrade `react` and `react-dom` to 18.2.0, in order to move toward Docusaurus 3.0 compatibility

## Related Issues and MRs

Closing #51 

## What changed

- Upgrade peer dependencies for `react` and `react-dom` within the project root, `docusaurus-plugin-stored-data`, and `jest-docusaurus`.
- Upgrade dependencies within `website` workspace.
- Install `@types/react` in project root
- Bump `@types/react` to 18.2.0 within packages + website workspaces

## Steps for reviewer

1. Pull changes and install
```
git checkout brian/react-18
yarn install
```
2. Verify react + react-dom have been updated throughout the project
3. Verify our plugins build properly
```
yarn dev docusaurus-plugin-stored-data
```
```
yarn dev jest-docusaurus
```

## Additional resources

- https://docusaurus.io/docs/migration/v3#react-v180