### PR TITLE
[DEV] MDX 3

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
     "@1password/docusaurus-plugin-stored-data": "workspace:^",
     "@docusaurus/core": "^2.3.1",
     "@docusaurus/preset-classic": "2.3.1",
-    "@mdx-js/react": "^1.6.22",
+    "@mdx-js/react": "^3.0.1",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,6 +3683,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdx-js/react@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@mdx-js/react@npm:3.0.1"
+  dependencies:
+    "@types/mdx": ^2.0.0
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 1063a597264f6a8840aa13274a99beef8983a88dd45b0c5b8e48e6216bc23d33e247da8e2d95d6e1874483f8b4e0903b166ce5046874aa7ffa2b1333057dcddf
+  languageName: node
+  linkType: hard
+
 "@mdx-js/util@npm:1.6.22":
   version: 1.6.22
   resolution: "@mdx-js/util@npm:1.6.22"
@@ -4695,6 +4707,13 @@ __metadata:
   dependencies:
     "@types/unist": "*"
   checksum: 3f587bfc0a9a2403ecadc220e61031b01734fedaf82e27eb4d5ba039c0eb54db8c85681ccc070ab4df3f7ec711b736a82b990e69caa14c74bf7ac0ccf2ac7313
+  languageName: node
+  linkType: hard
+
+"@types/mdx@npm:^2.0.0":
+  version: 2.0.13
+  resolution: "@types/mdx@npm:2.0.13"
+  checksum: 195137b548e75a85f0558bb1ca5088aff1c01ae0fc64454da06085b7513a043356d0bb51ed559d3cbc7ad724ccd8cef2a7d07d014b89a47a74dff8875ceb3b15
   languageName: node
   linkType: hard
 
@@ -18623,7 +18642,7 @@ __metadata:
     "@docusaurus/preset-classic": 2.3.1
     "@docusaurus/theme-classic": ^2.3.1
     "@docusaurus/types": ^2.3.1
-    "@mdx-js/react": ^1.6.22
+    "@mdx-js/react": ^3.0.1
     "@tsconfig/docusaurus": ^1.0.6
     "@types/node": ^18.11.17
     clsx: ^1.2.1


### PR DESCRIPTION
## Summary

Upgrade `@mdx-js/react` to v3+, in order to move toward Docusaurus 3.0 compatibility

## Related Issues and MRs

Closing #56 

## What changed

- Upgrade `@mdx-js/react` to 3.0.1 within the website workspace

## Steps for reviewer

1. Pull changes and install
```
git checkout brian/mdx-3
yarn install
```
2. Verify `@mdx-js/react` has been updated throughout the project
3. Verify our plugins build properly
```
yarn dev docusaurus-plugin-stored-data
```
```
yarn dev jest-docusaurus
```

## Additional resources

- https://docusaurus.io/docs/migration/v3#upgrading-mdx